### PR TITLE
Upgrade to Crystal 1.0

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -42,6 +42,7 @@ jobs:
         BROWSER: ${{ matrix.browser }}
         NO_TRANSFER_TEST: TRUE
     - name: Deploy
+      if: github.ref == 'refs/heads/main'
       uses: JamesIves/github-pages-deploy-action@3.7.1
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/shard.yml
+++ b/shard.yml
@@ -10,6 +10,6 @@ description: |
 scripts:
   postinstall: bin/install_local_driver.sh
 
-crystal: 0.36.0
+crystal: ">= 0.36.0, < 2.0.0"
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: playwright
-version: 0.1.1
+version: 0.1.2
 
 authors:
   - Ali Naqvi <syed.alinaqvi@gmail.com>

--- a/src/playwright.cr
+++ b/src/playwright.cr
@@ -1,5 +1,5 @@
 module Playwright
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
   # :nodoc:
   alias Number = Int64 | Float64
   # :nodoc:


### PR DESCRIPTION
Hello!
I was recently looking at Playwright and saw this did not support Crystal 1.0 yet. I've tried to follow the pattern I've seen when allowing shards to continue working on earlier versions, while also working on newer versions.
I also noticed you were deploying the docs every time, but that step doesn't for forked repos, so I fixed it to only work on main branch.
One other thing, unless the docs generated are different for every matrix, you probably only want to deploy the docs when all the matrix builds are complete, instead of at the end of each individual matrix build. I'd recommend adding another job that only runs when the suite of matrix builds complete in order to deploy the docs.